### PR TITLE
Adding support for sending special Sumologic HTTP headers 

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,16 @@ var endpoint = 'YOUR_ENDPOINT'
 var url = endpoint + collectorCode;
 
 const sumologic = Sumologic.createClient({
-  url: url
+  url: url,
+  name: "SumoHttpCollector",   // optional
+  host: "webapp.dot.com",      // optional
+  category: "env/host/service" // optional
 });
+/**
+ * More info about name,host and category options are in section 
+ *  "Other Supported HTTP Headers"
+ *  at https://help.sumologic.com/Send_Data/Sources/02Sources_for_Hosted_Collectors/HTTP_Source/Upload_Data_to_an_HTTP_Source
+*/
 
 var cb = function (err, res) {
   if (err) {

--- a/lib/sumologic/client.js
+++ b/lib/sumologic/client.js
@@ -2,7 +2,6 @@
 
 var events = require('events'),
   util = require('util'),
-  qs = require('querystring'),
   common = require('./common'),
   sumologic = require('../sumologic'),
   stringifySafe = require('json-stringify-safe');
@@ -35,6 +34,9 @@ var Sumologic = exports.Sumologic = function (options) {
   this.url = options.url;
   this.json = options.json || null;
   this.auth = options.auth || null;
+  this.sumoName = options.name || null;
+  this.sumoHost = options.host || null;
+  this.sumoCategory = options.category || null;
   this.proxy = options.proxy || null;
   this.userAgent = 'logs-to-sumologic ' + sumologic.version;
 
@@ -74,6 +76,16 @@ Sumologic.prototype.log = function (msg, callback) {
       'content-length': Buffer.byteLength(msg)
     }
   };
+
+  if (this.sumoName) {
+    logOptions.headers['X-Sumo-Name'] = this.sumoName;
+  }
+  if (this.sumoHost) {
+    logOptions.headers['X-Sumo-Host'] = this.sumoHost;
+  }
+  if (this.sumoCategory) {
+    logOptions.headers['X-Sumo-Category'] = this.sumoCategory;
+  }
 
   common.sumologic(logOptions, callback, function (res, body) {
     try {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "logs-to-sumologic",
   "description": "A simple sumologic log client tool",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "author": "Richard Seldon<arcseldon@gmail.com>",
   "repository": {
     "type": "git",


### PR DESCRIPTION
according to https://help.sumologic.com/Send_Data/Sources/02Sources_for_Hosted_Collectors/HTTP_Source/Upload_Data_to_an_HTTP_Source (section: "Other Supported HTTP Headers") we're able to specify the source Name, Host and Category overriding the Collector's

I've already tested this and it works great. 

Please consider accepting this pull request.